### PR TITLE
Fix typo: `Histroies` -> `Histories`

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -15,7 +15,7 @@
     "message": "Tabs"
   },
   "histories": {
-    "message": "Histroies"
+    "message": "Histories"
   },
   "bookmarks": {
     "message": "Bookmarks"


### PR DESCRIPTION
#124