### PR TITLE
fixed frozen session's candidates

### DIFF
--- a/src/utils/sessions.js
+++ b/src/utils/sessions.js
@@ -10,10 +10,10 @@ export function session2candidate(session) {
   const { tab, window } = session;
   if (tab) {
     return {
-      id:         `session-tab-${tab.sessionId}`,
+      id:         `session-tab-${tab.sessionId}-${tab.windowId}-${tab.index}`,
       label:      `${tab.title}:${tab.url}`,
       type:       'session',
-      args:       [tab.sessionId, 'tab', tab.windowId],
+      args:       [tab.sessionId, 'tab', tab.windowId, tab.index],
       faviconUrl: getFaviconUrl(tab.url),
     };
   }

--- a/test/utils/sessions.test.js
+++ b/test/utils/sessions.test.js
@@ -11,9 +11,10 @@ import {
 const tabSession = {
   tab: {
     sessionId: 1,
+    index:     75,
     title:     'tab-title',
     url:       'https://example.com',
-    windowId:  1,
+    windowId:  5,
   },
 };
 
@@ -57,9 +58,9 @@ test.afterEach(() => {
 
 test.serial('session2candidate converts session to candidate', (t) => {
   t.deepEqual(session2candidate(tabSession), {
-    id:         'session-tab-1',
+    id:         'session-tab-1-5-75',
     label:      'tab-title:https://example.com',
-    args:       [1, 'tab', 1],
+    args:       [1, 'tab', 5, 75],
     faviconUrl: getFaviconUrl(tabSession.tab.url),
     type:       'session',
   });


### PR DESCRIPTION
When we use browser.sessions.getRecentlyClosed it may return several items with the same sessionId (e.g. two closed tabs during the same session). So id for session's candidate in utils/sessions.js/session2candidate will not be unique:

`session-tab-${tab.sessionId}`

If so, we'll have several items with the same id (and react has list items with the same key-attribute) in candidates list. That's why react cannot properly remove all session-candidates when candidates list have changed, and we can see such frozen items inside candidates' list:

![Screenshot_3](https://user-images.githubusercontent.com/2838600/60659473-249e9d80-9e5e-11e9-8118-24251a0f4af3.png)

How to reproduce (checked with Firefox only):
1. Open several web-pages and then close them.
2. Open popup (e.g with C-,)
3. Type 't'-letter
4. remove it (query will be empty)
5. repeat 2-3 items several times
